### PR TITLE
blob view: remove extra prefix in path value

### DIFF
--- a/include/blob.html
+++ b/include/blob.html
@@ -28,7 +28,7 @@
 {{ $ref := .RefName }}
 
 <p>ref: {{ $ref }}</p>
-<p>./<a href="/{{ $repo }}/tree/{{ $ref }}/{{ .ParentPath }}">{{ .ParentPath }}</a>/{{ .File.Name }}</p>
+<p><a href="/{{ $repo }}/tree/{{ $ref }}/{{ .ParentPath }}">{{ .ParentPath }}</a>/{{ .File.Name }}</p>
 
 <hr>
 


### PR DESCRIPTION
Files immediately under the root of the repo were being rendered as
`././name` because the template includes a static `./` value. Remove
that so the path is always accurate.