### PR TITLE
tree view: format preamble consistently with blob view

### DIFF
--- a/include/tree.html
+++ b/include/tree.html
@@ -27,13 +27,9 @@
   </div>
 </nav>
 
-ref: {{ .RefName }}
+<p>ref: {{ .RefName }}</p>
 
 <p><a href="/{{ $repo }}/tree/{{ $ref }}/{{ .ParentPath }}">{{ .ParentPath }}</a>/{{ $subtree}}</p>
-
-<p>
-    path: {{ .Path }}
-</p>
 
 <table>
     {{ range .Files }}


### PR DESCRIPTION
Wrap the ref in paragraph tags so the vertical alignment is consistent
with the content in the blob.html template, so that when the user
clicks through from a directory listing to an individual file the
header section of the page does not appear to change sizes.

Remove the extra path value, since it is the same as the parent path.