### PR TITLE
template cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export CGO_ENABLED=0
 
 all: smithy smithy.yml
 
-smithy: bin/statik
+smithy: bin/statik include/*.html
 	bin/statik -src=include -dest=pkg -f -m
 	go build -ldflags $(LDFLAGS) -o smithy main.go
 

--- a/include/404.html
+++ b/include/404.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 <h1>404 - Not Found</h1>
 

--- a/include/500.html
+++ b/include/500.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 <h1>500 - Unexpected Server Error</h1>
 

--- a/include/blob.html
+++ b/include/blob.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .RepoName }}
 

--- a/include/commit.html
+++ b/include/commit.html
@@ -23,7 +23,6 @@
   </div>
 </nav>
 
-<h1>{{ .RepoName }}</h1>
 <h2>commit {{ .Commit.Hash }}</h2>
 
 <p>Author: {{ .Commit.Author.Name }} <{{ .Commit.Author.Email }}></p>

--- a/include/commit.html
+++ b/include/commit.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .Name }}
 

--- a/include/commit.html
+++ b/include/commit.html
@@ -1,8 +1,8 @@
 {{ template "header" . }}
 
-{{ $repo := .Name }}
+{{ $repo := .RepoName }}
 
-<h1>{{ .Name }}</h1>
+<h1>{{ .RepoName }}</h1>
 
 <nav class="navbar navbar-expand navbar-light bg-light">
   <div class="collapse navbar-collapse" id="navbarNav">

--- a/include/header.html
+++ b/include/header.html
@@ -4,14 +4,14 @@
     <head>
         <meta charset="utf-8">
         <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>Smithy</title>
+        <title>{{ .Site.Title }}</title>
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <link rel="stylesheet" href="{{ css }}" />
     </head>
     <body>
         <nav class="navbar navbar-expand navbar-light bg-light fixed-top">
-            <a class="navbar-brand" href="/">Smithy</a>
+            <a class="navbar-brand" href="/">{{ .Site.Title }}</a>
             <div class="collapse navbar-collapse" id="navbarSupportedContent">
                 <ul class="navbar-nav mr-auto">
                     <li class="nav-item">

--- a/include/index.html
+++ b/include/index.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 <h3>{{ .Title }}</h3>
 

--- a/include/index.html
+++ b/include/index.html
@@ -1,8 +1,6 @@
 {{ template "header" . }}
 
-<h3>{{ .Title }}</h3>
-
-<p>{{ .Description }}</p>
+<p>{{ .Site.Description }}</p>
 
 <h3>Projects</h3>
 

--- a/include/log.html
+++ b/include/log.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .Name }}
 

--- a/include/log.html
+++ b/include/log.html
@@ -1,8 +1,8 @@
 {{ template "header" . }}
 
-{{ $repo := .Name }}
+{{ $repo := .RepoName }}
 
-<h1>{{ .Name }}</h1>
+<h1>{{ .RepoName }}</h1>
 
 <nav class="navbar navbar-expand navbar-light bg-light">
   <div class="collapse navbar-collapse" id="navbarNav">

--- a/include/refs.html
+++ b/include/refs.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .Name }}
 

--- a/include/refs.html
+++ b/include/refs.html
@@ -1,8 +1,8 @@
 {{ template "header" . }}
 
-{{ $repo := .Name }}
+{{ $repo := .RepoName }}
 
-<h1>{{ .Name }}</h1>
+<h1>{{ .RepoName }}</h1>
 
 <nav class="navbar navbar-expand navbar-light bg-light">
   <div class="collapse navbar-collapse" id="navbarNav">
@@ -28,9 +28,9 @@
 <table class="table">
     {{ range .Branches }}
       <tr>
-          <td>{{ .Name.Short }}</td>
-          <td><a href="/{{ $repo }}/log/{{ .Name.Short }}">log</a></td>
-          <td><a href="/{{ $repo }}/tree/{{ .Name.Short }}">tree</a></td>
+          <td>{{ .RepoName.Short }}</td>
+          <td><a href="/{{ $repo }}/log/{{ .RepoName.Short }}">log</a></td>
+          <td><a href="/{{ $repo }}/tree/{{ .RepoName.Short }}">tree</a></td>
       </tr>
     {{ end }}
 </table>
@@ -40,9 +40,9 @@
 <table class="table">
     {{ range .Tags }}
     <tr>
-        <td>{{ .Name.Short }}</td>
-        <td><a href="/{{ $repo }}/log/{{ .Name.Short }}">log</a></td>
-        <td><a href="/{{ $repo }}/tree/{{ .Name.Short }}">tree</a></td>
+        <td>{{ .RepoName.Short }}</td>
+        <td><a href="/{{ $repo }}/log/{{ .RepoName.Short }}">log</a></td>
+        <td><a href="/{{ $repo }}/tree/{{ .RepoName.Short }}">tree</a></td>
     </tr>
     {{ end }}
 </table>

--- a/include/repo-index.html
+++ b/include/repo-index.html
@@ -29,7 +29,7 @@
 
     <hr>
     <pre>
-$ git clone https://{{ .Host }}/git/{{ $repo }}
+$ git clone https://{{ .Site.Host }}/git/{{ $repo }}
     </pre>
   </div>
 </div>

--- a/include/repo-index.html
+++ b/include/repo-index.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .Name }}
 

--- a/include/repo-index.html
+++ b/include/repo-index.html
@@ -1,8 +1,8 @@
 {{ template "header" . }}
 
-{{ $repo := .Name }}
+{{ $repo := .RepoName }}
 
-<h1>{{ .Name }}</h1>
+<h1>{{ .RepoName }}</h1>
 
 <nav class="navbar navbar-expand navbar-light bg-light">
   <div class="collapse navbar-collapse" id="navbarNav">

--- a/include/tree.html
+++ b/include/tree.html
@@ -44,6 +44,6 @@
         </td>
     </tr>
     {{ end }}
-</ul>
+</table>
 
 {{ template "footer" }}

--- a/include/tree.html
+++ b/include/tree.html
@@ -1,4 +1,4 @@
-{{ template "header" }}
+{{ template "header" . }}
 
 {{ $repo := .RepoName }}
 {{ $subtree := .SubTree }}

--- a/pkg/smithy/smithy.go
+++ b/pkg/smithy/smithy.go
@@ -302,7 +302,7 @@ func RepoIndexView(ctx *gin.Context, urlParts []string) {
 	}
 
 	ctx.HTML(http.StatusOK, "repo-index.html", makeTemplateContext(smithyConfig, gin.H{
-		"Name":     repoName,
+		"RepoName": repoName,
 		"Branches": bs,
 		"Tags":     ts,
 		"Readme":   template.HTML(formattedReadme),
@@ -352,7 +352,7 @@ func RefsView(ctx *gin.Context, urlParts []string) {
 	}
 
 	ctx.HTML(http.StatusOK, "refs.html", makeTemplateContext(smithyConfig, gin.H{
-		"Name":     repoName,
+		"RepoName": repoName,
 		"Branches": bs,
 		"Tags":     ts,
 	}))
@@ -546,9 +546,9 @@ func LogView(ctx *gin.Context, urlParts []string) {
 	}
 
 	ctx.HTML(http.StatusOK, "log.html", makeTemplateContext(smithyConfig, gin.H{
-		"Name":    repoName,
-		"RefName": refNameString,
-		"Commits": commits,
+		"RepoName": repoName,
+		"RefName":  refNameString,
+		"Commits":  commits,
 	}))
 }
 
@@ -656,9 +656,9 @@ func CommitView(ctx *gin.Context, urlParts []string) {
 	}
 
 	ctx.HTML(http.StatusOK, "commit.html", makeTemplateContext(smithyConfig, gin.H{
-		"Name":    repoName,
-		"Commit":  commitObj,
-		"Changes": template.HTML(formattedChanges),
+		"RepoName": repoName,
+		"Commit":   commitObj,
+		"Changes":  template.HTML(formattedChanges),
 	}))
 }
 

--- a/pkg/smithy/smithy.go
+++ b/pkg/smithy/smithy.go
@@ -208,22 +208,37 @@ func RenderSyntaxHighlighting(file *object.File) (string, error) {
 }
 
 func Http404(ctx *gin.Context) {
-	ctx.HTML(http.StatusNotFound, "404.html", gin.H{})
+	smithyConfig := ctx.MustGet("config").(SmithyConfig)
+	ctx.HTML(http.StatusNotFound, "404.html", makeTemplateContext(smithyConfig, gin.H{}))
 }
 
 func Http500(ctx *gin.Context) {
-	ctx.HTML(http.StatusInternalServerError, "500.html", gin.H{})
+	smithyConfig := ctx.MustGet("config").(SmithyConfig)
+	ctx.HTML(http.StatusInternalServerError, "500.html",
+		makeTemplateContext(smithyConfig, gin.H{}))
+}
+
+func makeTemplateContext(config SmithyConfig, extra gin.H) gin.H {
+	results := gin.H{
+		"Site": gin.H{
+			"Title":       config.Title,
+			"Description": config.Description,
+			"Host":        config.Host,
+		},
+	}
+	for k, v := range extra {
+		results[k] = v
+	}
+	return results
 }
 
 func IndexView(ctx *gin.Context, urlParts []string) {
 	smithyConfig := ctx.MustGet("config").(SmithyConfig)
 	repos := smithyConfig.GetRepositories()
 
-	ctx.HTML(http.StatusOK, "index.html", gin.H{
-		"Repos":       repos,
-		"Title":       smithyConfig.Title,
-		"Description": smithyConfig.Description,
-	})
+	ctx.HTML(http.StatusOK, "index.html", makeTemplateContext(smithyConfig, gin.H{
+		"Repos": repos,
+	}))
 }
 
 func findMainBranch(ctx *gin.Context, repo *git.Repository) (string, *plumbing.Hash, error) {
@@ -286,15 +301,13 @@ func RepoIndexView(ctx *gin.Context, urlParts []string) {
 		}
 	}
 
-	ctx.HTML(http.StatusOK, "repo-index.html", gin.H{
+	ctx.HTML(http.StatusOK, "repo-index.html", makeTemplateContext(smithyConfig, gin.H{
 		"Name":     repoName,
 		"Branches": bs,
 		"Tags":     ts,
 		"Readme":   template.HTML(formattedReadme),
 		"Repo":     repo,
-
-		"Host": smithyConfig.Host,
-	})
+	}))
 }
 
 func RepoGitView(ctx *gin.Context, urlParts []string) {
@@ -338,11 +351,11 @@ func RefsView(ctx *gin.Context, urlParts []string) {
 		ts = []*plumbing.Reference{}
 	}
 
-	ctx.HTML(http.StatusOK, "refs.html", gin.H{
+	ctx.HTML(http.StatusOK, "refs.html", makeTemplateContext(smithyConfig, gin.H{
 		"Name":     repoName,
 		"Branches": bs,
 		"Tags":     ts,
-	})
+	}))
 }
 
 func TreeView(ctx *gin.Context, urlParts []string) {
@@ -414,12 +427,12 @@ func TreeView(ctx *gin.Context, urlParts []string) {
 	if treePath == "" {
 		entries := ConvertTreeEntries(tree.Entries)
 
-		ctx.HTML(http.StatusOK, "tree.html", gin.H{
+		ctx.HTML(http.StatusOK, "tree.html", makeTemplateContext(smithyConfig, gin.H{
 			"RepoName": repoName,
 			"RefName":  refNameString,
 			"Files":    entries,
 			"Path":     treePath,
-		})
+		}))
 		return
 	}
 
@@ -438,14 +451,14 @@ func TreeView(ctx *gin.Context, urlParts []string) {
 			return
 		}
 		entries := ConvertTreeEntries(subTree.Entries)
-		ctx.HTML(http.StatusOK, "tree.html", gin.H{
+		ctx.HTML(http.StatusOK, "tree.html", makeTemplateContext(smithyConfig, gin.H{
 			"RepoName":   repoName,
 			"ParentPath": parentPath,
 			"RefName":    refNameString,
 			"SubTree":    out.Name,
 			"Path":       treePath,
 			"Files":      entries,
-		})
+		}))
 		return
 	}
 
@@ -464,7 +477,7 @@ func TreeView(ctx *gin.Context, urlParts []string) {
 		Http404(ctx)
 		return
 	}
-	ctx.HTML(http.StatusOK, "blob.html", gin.H{
+	ctx.HTML(http.StatusOK, "blob.html", makeTemplateContext(smithyConfig, gin.H{
 		"RepoName":            repoName,
 		"RefName":             refNameString,
 		"File":                out,
@@ -472,7 +485,7 @@ func TreeView(ctx *gin.Context, urlParts []string) {
 		"Path":                treePath,
 		"Contents":            contents,
 		"ContentsHighlighted": template.HTML(syntaxHighlighted),
-	})
+	}))
 }
 
 func LogView(ctx *gin.Context, urlParts []string) {
@@ -532,11 +545,11 @@ func LogView(ctx *gin.Context, urlParts []string) {
 		commits = append(commits, c)
 	}
 
-	ctx.HTML(http.StatusOK, "log.html", gin.H{
+	ctx.HTML(http.StatusOK, "log.html", makeTemplateContext(smithyConfig, gin.H{
 		"Name":    repoName,
 		"RefName": refNameString,
 		"Commits": commits,
-	})
+	}))
 }
 
 func LogViewDefault(ctx *gin.Context, urlParts []string) {
@@ -642,11 +655,11 @@ func CommitView(ctx *gin.Context, urlParts []string) {
 		return
 	}
 
-	ctx.HTML(http.StatusOK, "commit.html", gin.H{
+	ctx.HTML(http.StatusOK, "commit.html", makeTemplateContext(smithyConfig, gin.H{
 		"Name":    repoName,
 		"Commit":  commitObj,
 		"Changes": template.HTML(formattedChanges),
-	})
+	}))
 }
 
 func ListBranches(r *git.Repository) ([]*plumbing.Reference, error) {


### PR DESCRIPTION
- fix closing tag in tree template
- remove redundant repo name in commit template
- always call repository name RepoName
- use consistent base template context
- pass context to the header template
- add dependency for binary on include files